### PR TITLE
Add configurable Dante interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ This project provides a Docker container for the Huawei UniVPN GUI client (versi
 
     # Time (in seconds) to wait for login before starting connectivity checks
     RECONNECT_GRACE_PERIOD=60
+
+    # Dante SOCKS5 outgoing VPN interface.
+    # Set this to the VPN interface name created in your environment, such as ipsec_vnic.
+    DANTE_INTERFACE=cnem_vnic
     ```
 
 3.  **Start the Container:**
@@ -85,6 +89,16 @@ This project provides a Docker container for the Huawei UniVPN GUI client (versi
 5.  **Use the Proxies:**
     - **SOCKS5:** `localhost:1080`
     - **HTTP:** `localhost:8888`
+
+    Dante waits for `DANTE_INTERFACE` before starting. The default is `cnem_vnic`; set it to the VPN interface name created in your environment, such as `ipsec_vnic`.
+    After the VPN is connected, you can check the interface name inside the container:
+    ```bash
+    docker compose exec univpn ip -br link
+    ```
+    For the CLI compose file, use:
+    ```bash
+    docker compose -f docker-compose-cli.yml exec univpn ip -br link
+    ```
 
 ## CLI-Only Docker Image
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,6 +69,10 @@
 
     # 启动后等待登录的宽限期 (秒)，在此期间不进行 Ping 检测
     RECONNECT_GRACE_PERIOD=60
+
+    # Dante SOCKS5 出口 VPN 网卡。
+    # 请设置为当前环境中 UniVPN 创建的 VPN 网卡名，例如 ipsec_vnic。
+    DANTE_INTERFACE=cnem_vnic
     ```
 
 3.  **启动容器:**
@@ -85,6 +89,16 @@
 5.  **使用代理:**
     - **SOCKS5:** `localhost:1080`
     - **HTTP:** `localhost:8888`
+
+    Dante 会等待 `DANTE_INTERFACE` 指定的网卡出现后再启动。默认值是 `cnem_vnic`；如果当前环境中 UniVPN 创建的是其他 VPN 网卡，例如 `ipsec_vnic`，请在 `.env` 中设置对应名称。
+    VPN 连接成功后，可以在容器内查看实际网卡名：
+    ```bash
+    docker compose exec univpn ip -br link
+    ```
+    如果使用 CLI compose 文件，请运行：
+    ```bash
+    docker compose -f docker-compose-cli.yml exec univpn ip -br link
+    ```
 
 ## 纯命令行 (CLI) Docker 镜像
 

--- a/danted.conf
+++ b/danted.conf
@@ -5,8 +5,8 @@ logoutput: /var/log/sockd.log
 # Listen on all IPs within the container on port 1080 for simplicity
 internal: 0.0.0.0 port = 1080
 
-# Let the kernel decide the outgoing interface based on routing table
-# This avoids needing the dynamic IP of cnem_vnic
+# Outgoing VPN interface for Dante. The startup wrapper can override this
+# with the DANTE_INTERFACE environment variable.
 external: cnem_vnic
 
 #authentication methods

--- a/docker-compose-cli.yml
+++ b/docker-compose-cli.yml
@@ -52,6 +52,9 @@ services:
       # --- How many seconds to wait before starting to ping (Time for you to type password) ---
       - RECONNECT_GRACE_PERIOD=${RECONNECT_GRACE_PERIOD:-60}
 
+      # --- Dante SOCKS5 outgoing VPN interface ---
+      - DANTE_INTERFACE=${DANTE_INTERFACE:-cnem_vnic}
+
       # You can add other ENV variables needed by the container/app here
       # Example (already set in Dockerfile, but could be overridden):
       # - TZ=Asia/Shanghai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,9 @@ services:
       # --- How many seconds to wait before starting to ping (Time for you to type password) ---
       - RECONNECT_GRACE_PERIOD=${RECONNECT_GRACE_PERIOD:-60}
 
+      # --- Dante SOCKS5 outgoing VPN interface ---
+      - DANTE_INTERFACE=${DANTE_INTERFACE:-cnem_vnic}
+
       # You can add other ENV variables needed by the container/app here
       # Example (already set in Dockerfile, but could be overridden):
       # - TZ=Asia/Shanghai

--- a/wait_and_start_dante.sh
+++ b/wait_and_start_dante.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
-INTERFACE="cnem_vnic"
+INTERFACE="${DANTE_INTERFACE:-cnem_vnic}"
 DANTE_COMMAND="/usr/sbin/danted -f /etc/danted.conf"
 CHECK_INTERVAL=5 # Seconds between checks
 MAX_CHECKS=60    # Wait a maximum of 5 minutes (60 checks * 5 seconds)
+
+if ! [[ "${INTERFACE}" =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+  echo "[Wrapper] ERROR: Invalid interface name: ${INTERFACE}" >&2
+  exit 1
+fi
+
+sed -i "s|^external:.*|external: ${INTERFACE}|" /etc/danted.conf
 
 echo "[Wrapper] Waiting for interface ${INTERFACE} to appear..."
 


### PR DESCRIPTION
This PR makes the Dante SOCKS5 outgoing VPN interface configurable.

By default it keeps the existing cnem_vnic interface, but users can now set `DANTE_INTERFACE` in `.env` or Compose to match the interface created by their UniVPN environment, for example `ipsec_vnic`.

The Dante startup wrapper updates `/etc/danted.conf` before starting and waits for the configured interface to appear. Documentation and both GUI/CLI Compose files were updated accordingly.